### PR TITLE
Add forever support to the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,22 @@ Simply call
 npm start
 ```
 
+### When deployed remotely
+
+When deployed remotely you will be accessing the instance via ssh. Starting the project as usual using `npm start` will result in the app being killed when you exit your ssh session.
+
+To get round this the project uses [Forever](https://github.com/foreverjs/forever). So on the remote server start the app using
+
+```bash
+npm run forever
+```
+
+This will start the app as a daemon process, with the logs going into files in the `logs` directory (you'll want to create this first using `mkdir logs`).
+
+Should you need to kill the process first run `node_modules/.bin/forever list`. This will give you details of the currently running script, including its PID.
+
+You can then stop it using `node_modules/.bin/forever stop 30183` where **30183** is the PID.
+
 ## Contributing to this project
 
 If you have an idea you'd like to contribute please log an issue.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "start": "node ./bin/www",
+    "forever": "forever start -m 5 -o ./logs/stdout -e ./logs/stderr bin/www",
     "lint": "standard"
   },
   "description": "WasteNodeJs",
@@ -29,6 +30,7 @@
     "debug": "~2.0.0",
     "dotenv": "^4.0.0",
     "express": "~4.9.0",
+    "forever": "^0.15.3",
     "jade": "~1.6.0",
     "morgan": "~1.3.0",
     "serve-favicon": "~2.1.3"


### PR DESCRIPTION
[Forever](https://github.com/foreverjs/forever) is a package that can be used to ensure a .js script runs continuously. Having deployed the project to an AWS instance, we can start it whilst ssh'd in, but the moment we close the terminal the process will be killed.

You can use things like [nohup](https://en.wikipedia.org/wiki/Nohup) to get round this, but **Forever** makes the process a little simpler, means the command is built into the project, and gives the additional benefit of restarting the server should it unexpectedly stop.