### PR TITLE
`Prefer` was listed in the request headers x2

### DIFF
--- a/contacts.js
+++ b/contacts.js
@@ -18,8 +18,7 @@ Contacts.prototype.get = function (req, res, next) {
     'OData-Version': '4.0',
     'Accept': 'application/json',
     'Content-Type': 'application/json; charset=utf-8',
-    'Prefer': 'odata.maxpagesize=500',
-    'Prefer': 'odata.include-annotations=OData.Community.Display.V1.FormattedValue'
+    'Prefer': 'odata.maxpagesize=500, odata.include-annotations=OData.Community.Display.V1.FormattedValue'
   }
 
   // set the crm request parameters

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "waste-permits-handshake-poc",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "scripts": {
     "start": "node ./bin/www",


### PR DESCRIPTION
Resolves a bug where the header `Prefer` was in the request header of [contacts.js](contacts.js) twice. Instead it should have been there only once, but the values separated by a comma.

This change fixes that issue.