### PR TITLE
Add integrations to CI services like Travis, Dave

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: node_js
+
+# Project was built against version 6 of Node so that is all we are interested
+# in testing
+node_js:
+  - "6"
+
+# Travis CI clones repositories to a depth of 50 commits, which is only really
+# useful if you are performing git operations.
+# https://docs.travis-ci.com/user/customizing-the-build/#Git-Clone-Depth
+git:
+  depth: 3
+
+# We cache the node_modules directory so subsequent builds are quicker
+cache:
+  directories:
+    - node_modules
+
+# Because we have no tests, we have to override the default (npm test) and
+# instead call what we want to check. In the case of this project its simply
+# that all code abides by Standard JS
+script:
+  - npm run lint

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 ﻿# Waste permits handshake POC
 
+[![Build Status](https://travis-ci.org/DEFRA/waste-permits-handshake-poc.svg?branch=master)](https://travis-ci.org/DEFRA/waste-permits-handshake-poc)
+[![NSP Status](https://nodesecurity.io/orgs/cruikshanks/projects/e47b548c-f123-4e84-b2f0-58834ca231f0/badge)](https://nodesecurity.io/orgs/cruikshanks/projects/e47b548c-f123-4e84-b2f0-58834ca231f0)
+[![Dependency Status](https://dependencyci.com/github/DEFRA/waste-permits-handshake-poc/badge)](https://dependencyci.com/github/DEFRA/waste-permits-handshake-poc)
+
 We are currently building the next generation of a waste permits solution as a [digital service](https://www.gov.uk/service-manual/service-standard). This will allow users in the future to more easily submit applications for permits online.
 
 Our current design is to marry a GOV.UK public web application built using [Node.js](https://nodejs.org/en/) with [Microsoft Dynamics](https://www.microsoft.com/en-gb/dynamics365/home) in the back end. In the future all permit applications will be recieved and managed in the **Dynamics** instance, and we feel it is the most suitable platform to build on for this.


### PR DESCRIPTION
This change adds integrations to the following CI services

- [Travis-CI](https://travis-ci.org/) - confirms that the project is building and all code matches StandardJS
- [Node Security](https://nodesecurity.io/) - continuous security monitoring for your node apps
- [Dave](https://david-dm.org/) - gives an overview of your project dependencies, the version you use and the latest available, so you can quickly see what's drifting
- [DependencyCI](https://dependencyci.com/) - checks for deprecated, unmaintained, unavailable, and unlicensed dependencies. Will also detail the licenses of your dependencies